### PR TITLE
Misc bugs fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -340,3 +340,7 @@ ASALocalRun/
 healthchecksdb
 Zigbee2MqttAssistant/appsettings.*.json
 .vscode/
+
+# Misc local docker build
+/Zigbee2MqttAssistant/app
+/Zigbee2MqttAssistant/apppublish

--- a/Zigbee2MqttAssistant/Models/Devices/ZigbeeDevice.cs
+++ b/Zigbee2MqttAssistant/Models/Devices/ZigbeeDevice.cs
@@ -2,7 +2,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.EntityFrameworkCore.Design;
 using Uno;
 
 namespace Zigbee2MqttAssistant.Models.Devices

--- a/Zigbee2MqttAssistant/Services/MqttConnectionService.cs
+++ b/Zigbee2MqttAssistant/Services/MqttConnectionService.cs
@@ -171,9 +171,10 @@ namespace Zigbee2MqttAssistant.Services
 		private static readonly string[] _topicsToIgnore =
 		{
 			"/bridge/config/devices/get", // request for a device list
-			"/bridge/config/permit_join", // setting allow join
-			"/bridge/config/rename", // request to rename a device
 			"/bridge/config/log_level", // request to change log level
+			"/bridge/config/permit_join", // setting allow join
+			"/bridge/config/remove", // request for a device remove
+			"/bridge/config/rename", // request to rename a device
 			"/bridge/networkmap", // request for a network map
 		};
 

--- a/Zigbee2MqttAssistant/Services/MqttConnectionService.cs
+++ b/Zigbee2MqttAssistant/Services/MqttConnectionService.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore.Migrations.Design;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using MQTTnet;
@@ -15,11 +14,9 @@ using MQTTnet.Client.Connecting;
 using MQTTnet.Client.Disconnecting;
 using MQTTnet.Client.Options;
 using MQTTnet.Client.Receiving;
-using MQTTnet.Diagnostics;
 using MQTTnet.Extensions.ManagedClient;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Remotion.Linq.Parsing.Structure.IntermediateModel;
 using Zigbee2MqttAssistant.Models.Mqtt;
 
 namespace Zigbee2MqttAssistant.Services
@@ -54,7 +51,7 @@ namespace Zigbee2MqttAssistant.Services
 			var baseHassTopic = $"{settings.HomeAssistantDiscoveryBaseTopic}/";
 
 			var regexOptions = RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant;
-			FriendlyNameExtractor = new Regex($"^{Regex.Escape(baseTopic)}(?<name>[^/]+)(?:/(?<state>(availability|state|config)))?$", regexOptions);
+			FriendlyNameExtractor = new Regex($"^{Regex.Escape(baseTopic)}(?<name>.+?)(?:/(?<state>(availability|state|config|config/devices)))?$", regexOptions);
 			HassDiscoveryExtractor = new Regex($"^{Regex.Escape(baseHassTopic)}(?<class>[^/]+)/(?<deviceId>[^/]+)/(?<component>[^/]+)/(?<config>config)?$", regexOptions);
 			_setTopicRegex = new Regex($"^{Regex.Escape(baseTopic)}(?<name>[^/]+)/set$", regexOptions);
 		}
@@ -198,11 +195,6 @@ namespace Zigbee2MqttAssistant.Services
 				return Task.CompletedTask; // this one too
 			}
 
-			if (DispatchZigbee2MqttMessage(msg))
-			{
-				return Task.CompletedTask;
-			}
-
 			if (DispatchHassDiscoveryMessage(msg))
 			{
 				return Task.CompletedTask;
@@ -214,6 +206,11 @@ namespace Zigbee2MqttAssistant.Services
 			}
 
 			if (DispatchLogMessage(msg))
+			{
+				return Task.CompletedTask;
+			}
+
+			if (DispatchZigbee2MqttMessage(msg))
 			{
 				return Task.CompletedTask;
 			}

--- a/Zigbee2MqttAssistant/Views/Home/Index.cshtml
+++ b/Zigbee2MqttAssistant/Views/Home/Index.cshtml
@@ -79,10 +79,14 @@
                     {
                         <span class="badge badge-dark">@entity.Component</span>
                     }
-                    @if (device.Entities.Length == 0)
+                    @if (device.Type?.Equals("Coordinator", StringComparison.CurrentCultureIgnoreCase) ?? false)
                     {
-                        <span class="badge badge-danger">NO COMPONENTS DEFINED</span>
-                        <span>Maybe this device is not known to Zigbee2Mqtt?</span>
+                        <span class="badge badge-dark">@device.Type</span>
+                    }
+                    else if (device.Entities.Length == 0)
+                    {
+                        <span class="badge badge-danger">NO COMPONENTS</span>
+                        <span>Maybe this device is not (yet) supported by Zigbee2Mqtt?</span>
                     }
                 </td>
             </tr>


### PR DESCRIPTION
* Fixed warning described in #43 (`zigbee2mqtt/bridge/config/remove`)
* Now supports devices with a `/` in their name
* Stop displaying the coordinator (Z2M edge) as a no-components device #48
