### PR TITLE
Fix bouncy network map by customizing the physics in vis.js

### DIFF
--- a/Zigbee2MqttAssistant/Views/Home/Map.cshtml
+++ b/Zigbee2MqttAssistant/Views/Home/Map.cshtml
@@ -68,7 +68,20 @@
 
     (function (ctl) {
         const options = {
-            autoResize: true
+            autoResize: true,
+            physics: {
+                enabled: true,
+                minVelocity: 1,
+                maxVelocity: 50,
+                repulsion: {
+                    nodeDistance: 200
+                },
+                stabilization: {
+                    enabled: true,
+                    iterations: 10
+                },
+                solver: 'repulsion'
+            }
         };
 
         const nodes = new vis.DataSet([


### PR DESCRIPTION
Fixes #120 

Sets physics options in vis.js so it stops bouncing after a very short time while making sure nodes are not too close together.