### PR TITLE
Implemtation of OTA Update and show firmware version of device. Fixes #184

### DIFF
--- a/Zigbee2MqttAssistant/Controllers/HomeController.cs
+++ b/Zigbee2MqttAssistant/Controllers/HomeController.cs
@@ -136,6 +136,15 @@ namespace Zigbee2MqttAssistant.Controllers
 			return RedirectToAction("Status");
 		}
 
+		[HttpPost]
+		public async Task<IActionResult> OtaUpdateDevice(string id)
+		{
+			id = Uri.UnescapeDataString(id);
+			await _operationService.OtaUpdateDevice(id);
+
+			return RedirectToAction("Status");
+		}
+
 		public async Task<IActionResult> SetLogLevel(string level)
 		{
 			await _operationService.SetLogLevel(level);

--- a/Zigbee2MqttAssistant/Models/Devices/ZigbeeDevice.cs
+++ b/Zigbee2MqttAssistant/Models/Devices/ZigbeeDevice.cs
@@ -44,6 +44,10 @@ namespace Zigbee2MqttAssistant.Models.Devices
 
 		public long? HardwareVersion { get; }
 
+		public string FirmwareVersion { get; }
+
+		public bool? IsOtaAvailable { get; }
+
 		public string Type { get; }
 
 		public ImmutableArray<HomeAssistantEntity> Entities { get; } = ImmutableArray<HomeAssistantEntity>.Empty;

--- a/Zigbee2MqttAssistant/Services/BrigeOperationService.cs
+++ b/Zigbee2MqttAssistant/Services/BrigeOperationService.cs
@@ -95,5 +95,14 @@ namespace Zigbee2MqttAssistant.Services
 		public Task ManualRefreshDevicesList() => _mqtt.SendDevicesRequest();
 
 		public Task ManualRefreshNetworkScan() => _mqtt.SendNetworkScanRequest();
+
+		public async Task OtaUpdateDevice(string deviceId)
+		{
+			var device = _stateService.FindDeviceById(deviceId, out _);
+			if (device != null)
+			{
+				await _mqtt.OtaUpdateDevice(device.FriendlyName);
+			}
+		}
 	}
 }

--- a/Zigbee2MqttAssistant/Services/IBridgeOperationService.cs
+++ b/Zigbee2MqttAssistant/Services/IBridgeOperationService.cs
@@ -15,5 +15,6 @@ namespace Zigbee2MqttAssistant.Services
 		Task SetLogLevel(string level);
 		Task ManualRefreshDevicesList();
 		Task ManualRefreshNetworkScan();
+		Task OtaUpdateDevice(string deviceId);
 	}
 }

--- a/Zigbee2MqttAssistant/Services/MqttConnectionService.cs
+++ b/Zigbee2MqttAssistant/Services/MqttConnectionService.cs
@@ -69,6 +69,18 @@ namespace Zigbee2MqttAssistant.Services
 			Disconnect();
 		}
 
+		public async Task OtaUpdateDevice(string deviceFriendlyName)
+		{
+			var device = _stateService.FindDeviceById(deviceFriendlyName, out _);
+			
+			var msg = new MqttApplicationMessageBuilder()
+				.WithTopic($"{_settings.CurrentSettings.BaseTopic}/bridge/ota_update/update")
+				.WithPayload(device.FriendlyName)
+				.Build();
+
+			await _client.PublishAsync(msg);
+		}
+
 		private async Task Connect()
 		{
 			Disconnect();
@@ -304,6 +316,7 @@ namespace Zigbee2MqttAssistant.Services
 			"/bridge/config/force_remove", // request for a device remove
 			"/bridge/config/rename", // request to rename a device
 			"/bridge/configure", // request to configure a device
+			"/bridge/ota_update", // request to ota update a device
 		};
 
 		private Regex _setTopicRegex;

--- a/Zigbee2MqttAssistant/Views/Home/Device.cshtml
+++ b/Zigbee2MqttAssistant/Views/Home/Device.cshtml
@@ -94,7 +94,7 @@ else
                     Firmware update is available
                 </div>
                 <div class="alert-info">
-                    You can Over-The-Air update you device. Use it wisely, it generates alot of network traffic.
+                    You can Over-The-Air update your device. Use it wisely, it generates a lot of network traffic.
                 </div>
 
                 <form asp-action="OtaUpdateDevice" method="post" asp-route-id="@device.FriendlyName">

--- a/Zigbee2MqttAssistant/Views/Home/Device.cshtml
+++ b/Zigbee2MqttAssistant/Views/Home/Device.cshtml
@@ -59,29 +59,62 @@ else
         </span>
     }
     Model is <span class="badge badge-primary">@(device.Model ?? "unknown")</span> by <span class="badge badge-secondary">@(device.Manufacturer ?? "unknown")</span>.<br/>
-    Hardware version is <code>@(device.HardwareVersion?.ToString() ?? "unknown")</code>.<br />
+    Hardware version is <code>@(device.HardwareVersion?.ToString() ?? "unknown")</code>.<br />Firmware version is <code>@(device.FirmwareVersion ?? "unknown")</code>.<br/>
     This device type is <span class="badge badge-secondary">@(device.Type ?? "unknown")</span><br/>
 </p>
 
 @*@if (device.ZigbeeId != null)
+    {
+        <p>
+            Route to coordinator...
+            <br />
+            @foreach (var parentDevice in Model.RouteToCoordinator)
+            {
+                <span class="badge badge-dark">@parentDevice.FriendlyName</span>
+            }
+            @if (Model.RouteReachCoordinator)
+            {
+                <span class="badge alert-primary">Coordinator</span>
+            }
+            else
+            {
+                <span class="badge alert-danger">NO KNOWN ROUTE TO COORDINATOR</span>
+            }
+        </p>
+    }*@
+
+@if (device.IsOtaAvailable.HasValue)
 {
-    <p>
-        Route to coordinator...
-        <br />
-        @foreach (var parentDevice in Model.RouteToCoordinator)
-        {
-            <span class="badge badge-dark">@parentDevice.FriendlyName</span>
-        }
-        @if (Model.RouteReachCoordinator)
-        {
-            <span class="badge alert-primary">Coordinator</span>
-        }
-        else
-        {
-            <span class="badge alert-danger">NO KNOWN ROUTE TO COORDINATOR</span>
-        }
-    </p>
-}*@
+    <div class="card">
+        <div class="card-body">
+            <h5 class="card-title">OTA update</h5>
+            @if (device.IsOtaAvailable == true)
+            {
+                <div class="badge badge-secondary">
+                    Firmware update is available
+                </div>
+                <div class="alert-info">
+                    You can Over-The-Air update you device. Use it wisely, it generates alot of network traffic.
+                </div>
+
+                <form asp-action="OtaUpdateDevice" method="post" asp-route-id="@device.FriendlyName">
+                    <button class="btn btn-outline-secondary" type="submit">Update firmware</button>
+                </form>
+
+                <small class="form-text text-secondary">
+                    Some devices requires a power cycle before the update can be performed. Do not power of the device while updating.
+                </small>
+                <small class="form-text text-danger text-capitalize">You should check Zigbee2Mqtt logs to see if the OTA update is successful.</small>
+            }
+            else
+            {
+                <div class="badge badge-secondary">
+                    This device firmware is up-to-date
+                </div>
+            }
+        </div>
+    </div>
+}
 
 <div class="card">
     <div class="card-body">

--- a/Zigbee2MqttAssistant/appsettings.json
+++ b/Zigbee2MqttAssistant/appsettings.json
@@ -6,10 +6,8 @@
   },
   "AllowedHosts": "*",
   "settings": {
-    "MqttServer": "192.168.1.224",
-    "MqttPort": 1883, 
-    "MqttUsername": "",
-    "MqttPassword": "",
-    "Basetopic":  "zigbee2mqtt2" 
+    //"MqttServer": "mqtt",
+    //"MqttUsername": "",	
+    //"MqttPassword": ""
   }
 }

--- a/Zigbee2MqttAssistant/appsettings.json
+++ b/Zigbee2MqttAssistant/appsettings.json
@@ -6,8 +6,10 @@
   },
   "AllowedHosts": "*",
   "settings": {
-    //"MqttServer": "mqtt",
-    //"MqttUsername": "",
-    //"MqttPassword": ""
+    "MqttServer": "192.168.1.224",
+    "MqttPort": 1883, 
+    "MqttUsername": "",
+    "MqttPassword": "",
+    "Basetopic":  "zigbee2mqtt2" 
   }
 }


### PR DESCRIPTION
Fixes #184 
Implements OTA Update and will show device firmware verson

If the device is OTA capable and zigbee2mqtt has flagged it as update_available a new option will present

If the device can update this will show:
![firmware_available](https://user-images.githubusercontent.com/6589760/75497790-adf27980-59c5-11ea-9969-c39801bb7e56.PNG)

If the device is up to date, this will show:
![firmware_is_uptodate](https://user-images.githubusercontent.com/6589760/75497822-be0a5900-59c5-11ea-962f-8d41bde1afc9.PNG)

If the device is not OTA updatable. Nothing will show.
If device firmware verson is available, it will show, else it will say "unknown"

The OTA update option will be visible when the device has reported its status ti zigbee2mqtt.
So, when starting Zigbe2mqttAssistant, no OTA update will show, but after some time it will be available (if device supports it, and zigbee2mqtt supports that device)