### PR TITLE
Badge on index page showing id device has new firmware available #206

### DIFF
--- a/Zigbee2MqttAssistant/Views/Home/Index.cshtml
+++ b/Zigbee2MqttAssistant/Views/Home/Index.cshtml
@@ -78,6 +78,13 @@
                             <span class="badge badge-warning">weak link</span>
                         }
                     }
+                    @if (device.IsOtaAvailable.HasValue)
+                    {
+                        if (device.IsOtaAvailable.Value)
+                        {
+                            <span class="badge badge-secondary">firmware update available</span>
+                        }
+                    }
 
                     @if (device.BatteryLevel.HasValue)
                     {


### PR DESCRIPTION
Easier overview of device firmware availability
Fixes #206 

Ok to merge if text and color of badge is ok.
I tried red, but red sticks out and is warning for weak link
yellow/orange is unresponsive warning
green, almost all have green already (last seen)
gray.. doesn't stick out too much and not so common on index page